### PR TITLE
Lazy load generatedResourcesFoldername

### DIFF
--- a/src/main/java/com/mytaxi/apis/phrase/tasks/FileService.java
+++ b/src/main/java/com/mytaxi/apis/phrase/tasks/FileService.java
@@ -30,20 +30,6 @@ class FileService
     private static final String PROJECT_ID_PLACEHOLDER = "{projectid}";
     private static final String BRANCH_PLACEHOLDER = "{branch}";
 
-
-    FileService()
-    {
-        try
-        {
-            generatedResourcesFoldername = new ClassPathResource("/").getFile().getPath();
-        }
-        catch (final Exception e)
-        {
-            LOG.error("could not get default ClassPathResource. use /generated-resources/ instead");
-        }
-    }
-
-
     public void saveToFile(final String projectId, final byte[] translationByteArray, final String locale) throws IOException
     {
         saveToFile(projectId, MASTER_BRANCH, translationByteArray, locale);
@@ -82,7 +68,7 @@ class FileService
 
     private void initMessageDirectory() throws IOException
     {
-        messagesDirectory = Paths.get(firstNonNull(generatedResourcesFoldername, GENERATED_RESOURCES_FOLDERNAME));
+        messagesDirectory = Paths.get(firstNonNull(getGeneratedResourcesFoldername(), GENERATED_RESOURCES_FOLDERNAME));
         Files.createDirectories(messagesDirectory);
     }
 
@@ -152,6 +138,18 @@ class FileService
 
     public String getGeneratedResourcesFoldername()
     {
+        if (generatedResourcesFoldername == null)
+        {
+            try
+            {
+                generatedResourcesFoldername = new ClassPathResource("/").getFile().getPath();
+            }
+            catch (final Exception e)
+            {
+                LOG.error("could not get default ClassPathResource. use /generated-resources/ instead");
+            }
+        }
+
         return generatedResourcesFoldername;
     }
 


### PR DESCRIPTION
When using this from a maven plugin, the getting the ClassPathResource
path fails, causing an error to be logged, even if the path is going to
be set explicitly.
By moving the initialization of the path to the getter, trying to get
the path automatically can be omitted if it is set explicitly, avoiding
the error message that doesn't make any sense in this case.