### PR TITLE
Add support for download translations by tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.free-now.apis</groupId>
     <artifactId>phrase-java-client</artifactId>
     <version>2.1.1-SNAPSHOT</version>
     <name>phrase-api</name>
+
     <description>This projects contains of services to handle the translations from [PhraseApp API
-        v2](http://docs.phraseapp.com/api/v2/). It's supposed to expose Phrase translations as POJO or as File within the java world.</description>
+        v2](http://docs.phraseapp.com/api/v2/). It's supposed to expose Phrase translations as POJO or as File within the java world.
+    </description>
+
     <url>https://github.com/freenowtech/phrase-java-client</url>
 
     <licenses>
@@ -67,14 +71,14 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.13</version>
         </dependency>
 
         <!-- General Java Stuff -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>30.0-jre</version>
         </dependency>
 
         <!-- Just the annotations; use this dependency if you want to attach annotations
@@ -117,7 +121,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -131,7 +135,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.6</version>
+            <version>1.2.9</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.free-now.apis</groupId>
     <artifactId>phrase-java-client</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>phrase-api</name>
 
     <description>This projects contains of services to handle the translations from [PhraseApp API

--- a/src/main/java/com/freenow/apis/phrase/api/localedownload/PhraseLocaleDownloadAPI.java
+++ b/src/main/java/com/freenow/apis/phrase/api/localedownload/PhraseLocaleDownloadAPI.java
@@ -115,15 +115,15 @@ public class PhraseLocaleDownloadAPI extends GenericPhraseAPI<byte[]>
 
             final URIBuilder builder = createUriBuilder(requestPath, parameters);
 
-            final String requestPathWithTags = requestPath.concat(getNonNullString(tags));
+            final String requestPathEtagCacheKey = requestPath.concat(getNonNullString(tags));
 
-            final HttpEntity<Object> requestEntity = createHttpEntity(requestPathWithTags);
+            final HttpEntity<Object> requestEntity = createHttpEntity(requestPathEtagCacheKey);
 
             final URI uri = builder.build();
 
             final ResponseEntity<byte[]> responseEntity = requestPhrase(requestEntity, uri, byte[].class);
 
-            return handleResponse(projectId, requestPathWithTags, responseEntity);
+            return handleResponse(projectId, requestPathEtagCacheKey, responseEntity);
 
         }
         catch (final URISyntaxException e)

--- a/src/main/java/com/freenow/apis/phrase/api/localedownload/PhraseLocaleDownloadAPI.java
+++ b/src/main/java/com/freenow/apis/phrase/api/localedownload/PhraseLocaleDownloadAPI.java
@@ -37,6 +37,8 @@ public class PhraseLocaleDownloadAPI extends GenericPhraseAPI<byte[]>
 
     private static final String PARAMETER_BRANCH = "branch";
 
+    private static final String PARAMETER_TAGS = "tags";
+
     private static final String PHRASE_LOCALES_DOWNLOAD_PATH = "/api/v2/projects/" + PLACEHOLDER_PROJECT_ID +
         "/locales/" + PLACEHOLDER_LOCALE_ID + "/download";
 
@@ -62,19 +64,30 @@ public class PhraseLocaleDownloadAPI extends GenericPhraseAPI<byte[]>
         super(createRestTemplateWithConverter(), scheme, host, authToken);
     }
 
-
     public byte[] downloadLocale(final String projectId, final String localeId)
     {
-        return downloadLocale(projectId, DEFAULT_BRANCH, localeId, DEFAULT_FILE_FORMAT);
+        return downloadLocale(projectId, DEFAULT_BRANCH, localeId, DEFAULT_FILE_FORMAT, null);
+    }
+
+
+    public byte[] downloadLocale(final String projectId, final String localeId, final String tags)
+    {
+        return downloadLocale(projectId, DEFAULT_BRANCH, localeId, DEFAULT_FILE_FORMAT, tags);
     }
 
 
     public byte[] downloadLocale(final String projectId, final String localeId, final Format format)
     {
-        return downloadLocale(projectId, DEFAULT_BRANCH, localeId, format);
+        return downloadLocale(projectId, DEFAULT_BRANCH, localeId, format, null);
     }
 
-    public byte[] downloadLocale(final String projectId, final String branch, final String localeId, final Format format)
+
+    public byte[] downloadLocale(final String projectId, final String localeId, final Format format, final String tags)
+    {
+        return downloadLocale(projectId, DEFAULT_BRANCH, localeId, format, tags);
+    }
+
+    public byte[] downloadLocale(final String projectId, final String branch, final String localeId, final Format format, final String tags)
     {
         Preconditions.checkNotNull(projectId, "ProjectIds may not be null.");
         Preconditions.checkNotNull(format, "format may not be null.");
@@ -96,15 +109,21 @@ public class PhraseLocaleDownloadAPI extends GenericPhraseAPI<byte[]>
                 parameters.add(new BasicNameValuePair(PARAMETER_BRANCH, branch));
             }
 
+            if (tags != null && !tags.trim().isEmpty()) {
+                parameters.add(new BasicNameValuePair(PARAMETER_TAGS, tags));
+            }
+
             final URIBuilder builder = createUriBuilder(requestPath, parameters);
 
-            final HttpEntity<Object> requestEntity = createHttpEntity(requestPath);
+            final String requestPathWithTags = requestPath.concat(getNonNullString(tags));
+
+            final HttpEntity<Object> requestEntity = createHttpEntity(requestPathWithTags);
 
             final URI uri = builder.build();
 
             final ResponseEntity<byte[]> responseEntity = requestPhrase(requestEntity, uri, byte[].class);
 
-            return handleResponse(projectId, requestPath, responseEntity);
+            return handleResponse(projectId, requestPathWithTags, responseEntity);
 
         }
         catch (final URISyntaxException e)
@@ -123,4 +142,8 @@ public class PhraseLocaleDownloadAPI extends GenericPhraseAPI<byte[]>
         return createPath(PHRASE_LOCALES_DOWNLOAD_PATH, placeholders);
     }
 
+    private String getNonNullString(final String value) {
+        if (value == null) return "";
+        return value.trim();
+    }
 }

--- a/src/main/java/com/freenow/apis/phrase/api/tag/PhraseTagAPI.java
+++ b/src/main/java/com/freenow/apis/phrase/api/tag/PhraseTagAPI.java
@@ -1,0 +1,112 @@
+package com.freenow.apis.phrase.api.tag;
+
+import com.freenow.apis.phrase.api.GenericPhraseAPI;
+import com.freenow.apis.phrase.api.tag.dto.PhraseTagWithStatsDTO;
+import com.freenow.apis.phrase.exception.PhraseAppApiException;
+import com.google.common.base.Preconditions;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import static com.freenow.apis.phrase.api.localedownload.PhraseLocaleDownloadAPI.DEFAULT_BRANCH;
+
+public class PhraseTagAPI extends GenericPhraseAPI<PhraseTagWithStatsDTO>
+{
+    private static final Logger LOG = LoggerFactory.getLogger(PhraseTagAPI.class);
+
+    // ---- configuration -----
+    private static final String PLACEHOLDER_PROJECT_ID = "{projectid}";
+
+    private static final String PLACEHOLDER_TAG_NAME = "{tagName}";
+
+    private static final String PHRASE_TRANSLATIONS_PATH = "/api/v2/projects/" + PLACEHOLDER_PROJECT_ID + "/tags/" + PLACEHOLDER_TAG_NAME;
+
+    private static final String PARAMETER_BRANCH = "branch";
+
+
+    protected PhraseTagAPI(final RestTemplate restTemplate, final String authToken)
+    {
+        super(restTemplate, authToken);
+    }
+
+
+    public PhraseTagAPI(final String authToken, final String scheme, final String host)
+    {
+        super(createRestTemplateWithConverter(), scheme, host, authToken);
+    }
+
+
+    public PhraseTagAPI(final String authToken)
+    {
+        super(createRestTemplateWithConverter(), authToken);
+    }
+
+
+    public PhraseTagWithStatsDTO getSingleTag(String projectId, String tagName) throws PhraseAppApiException
+    {
+        return getSingleTag(projectId, DEFAULT_BRANCH, tagName);
+    }
+
+
+    public PhraseTagWithStatsDTO getSingleTag(final String projectId, final String branch, final String tagName) throws PhraseAppApiException
+    {
+        Preconditions.checkNotNull(projectId, "ProjectId must not be null.");
+        Preconditions.checkNotNull(tagName, "Tag name must not be null.");
+        LOG.trace("Start to retrieve tag for projectId: {} and name: {}", projectId, tagName);
+
+        try
+        {
+            final String requestPath = createRequestPath(projectId, tagName);
+
+            LOG.trace("Call requestPath: {} to get tag from phrase.", requestPath);
+
+            final List<NameValuePair> parameters;
+            if (!DEFAULT_BRANCH.equals(branch))
+            {
+                parameters = new ArrayList<>(1);
+                parameters.add(new BasicNameValuePair(PARAMETER_BRANCH, branch));
+            }
+            else
+            {
+                parameters = Collections.emptyList();
+            }
+
+            final URI uri = createUriBuilder(requestPath, parameters)
+                .build();
+
+            final HttpEntity<Object> requestEntity = createHttpEntity(requestPath);
+
+            final ResponseEntity<PhraseTagWithStatsDTO> responseEntity = requestPhrase(
+                requestEntity,
+                uri,
+                PhraseTagWithStatsDTO.class);
+
+            return handleResponse(projectId, requestPath, responseEntity);
+        }
+        catch (URISyntaxException e)
+        {
+            throw new RuntimeException("Something goes wrong due building of the request URI", e);
+        }
+    }
+
+
+    private String createRequestPath(final String projectId, final String tagName)
+    {
+        Map<String, String> placeholders = new HashMap<String, String>();
+        placeholders.put(PLACEHOLDER_PROJECT_ID, projectId);
+        placeholders.put(PLACEHOLDER_TAG_NAME, tagName);
+        return createPath(PHRASE_TRANSLATIONS_PATH, placeholders);
+    }
+
+}

--- a/src/main/java/com/freenow/apis/phrase/api/tag/dto/LocalePreviewDTO.java
+++ b/src/main/java/com/freenow/apis/phrase/api/tag/dto/LocalePreviewDTO.java
@@ -1,0 +1,66 @@
+package com.freenow.apis.phrase.api.tag.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LocalePreviewDTO {
+
+    private String id;
+
+    private String name;
+
+    private String code;
+
+    private LocalePreviewWithStatsStatisticsDTO statistics;
+
+    public LocalePreviewDTO() {
+    }
+
+    public LocalePreviewDTO(
+            final String id,
+            final String name,
+            final String code,
+            final LocalePreviewWithStatsStatisticsDTO statistics) {
+        this.id = id;
+        this.name = name;
+        this.code = code;
+        this.statistics = statistics;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(final String code) {
+        this.code = code;
+    }
+
+    public LocalePreviewWithStatsStatisticsDTO getStatistics() {
+        return statistics;
+    }
+
+    public void setStatistics(LocalePreviewWithStatsStatisticsDTO statistics) {
+        this.statistics = statistics;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("LocalePreviewDTO{id='%s', name='%s', code='%s'}", id, name, code);
+    }
+}

--- a/src/main/java/com/freenow/apis/phrase/api/tag/dto/LocalePreviewWithStatsStatisticsDTO.java
+++ b/src/main/java/com/freenow/apis/phrase/api/tag/dto/LocalePreviewWithStatsStatisticsDTO.java
@@ -1,0 +1,66 @@
+package com.freenow.apis.phrase.api.tag.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LocalePreviewWithStatsStatisticsDTO {
+
+    @JsonProperty("keys_total_count")
+    private Integer keysTotalCount;
+
+    @JsonProperty("translations_completed_count")
+    private Integer translationsCompletedCount;
+
+    @JsonProperty("translations_unverified_count")
+    private Integer translationsUnverifiedCount;
+
+    @JsonProperty("keys_untranslated_count")
+    private Integer keysUntranslatedCount;
+
+    public LocalePreviewWithStatsStatisticsDTO() { }
+
+    public LocalePreviewWithStatsStatisticsDTO(
+            final Integer keysTotalCount,
+            final Integer translationsCompletedCount,
+            final Integer translationsUnverifiedCount,
+            final Integer keysUntranslatedCount
+    ) {
+        this.keysTotalCount = keysTotalCount;
+        this.translationsCompletedCount = translationsCompletedCount;
+        this.translationsUnverifiedCount = translationsUnverifiedCount;
+        this.keysUntranslatedCount = keysUntranslatedCount;
+    }
+
+    public Integer getKeysTotalCount() {
+        return keysTotalCount;
+    }
+
+    public void setKeysTotalCount(Integer keysTotalCount) {
+        this.keysTotalCount = keysTotalCount;
+    }
+
+    public Integer getTranslationsCompletedCount() {
+        return translationsCompletedCount;
+    }
+
+    public void setTranslationsCompletedCount(Integer translationsCompletedCount) {
+        this.translationsCompletedCount = translationsCompletedCount;
+    }
+
+    public Integer getTranslationsUnverifiedCount() {
+        return translationsUnverifiedCount;
+    }
+
+    public void setTranslationsUnverifiedCount(Integer translationsUnverifiedCount) {
+        this.translationsUnverifiedCount = translationsUnverifiedCount;
+    }
+
+    public Integer getKeysUntranslatedCount() {
+        return keysUntranslatedCount;
+    }
+
+    public void setKeysUntranslatedCount(Integer keysUntranslatedCount) {
+        this.keysUntranslatedCount = keysUntranslatedCount;
+    }
+}

--- a/src/main/java/com/freenow/apis/phrase/api/tag/dto/PhraseTagWithStatsDTO.java
+++ b/src/main/java/com/freenow/apis/phrase/api/tag/dto/PhraseTagWithStatsDTO.java
@@ -1,0 +1,79 @@
+package com.freenow.apis.phrase.api.tag.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.List;
+
+public class PhraseTagWithStatsDTO {
+
+    private String name;
+
+    @JsonProperty("keys_count")
+    private Integer keysCount;
+
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    @JsonProperty("updated_at")
+    private Date updatedAt;
+
+    private List<TagWithStatsStatisticsDTO> statistics;
+
+    public PhraseTagWithStatsDTO() {
+    }
+
+    public PhraseTagWithStatsDTO(
+            final String name,
+            final Integer keysCount,
+            final Date createdAt,
+            final Date updatedAt,
+            final List<TagWithStatsStatisticsDTO> statistics
+    ) {
+        this.name = name;
+        this.keysCount = keysCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.statistics = statistics;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public Integer getKeysCount() {
+        return keysCount;
+    }
+
+    public void setKeysCount(final Integer keysCount) {
+        this.keysCount = keysCount;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public List<TagWithStatsStatisticsDTO> getStatistics() {
+        return statistics;
+    }
+
+    public void setStatistics(final List<TagWithStatsStatisticsDTO> statistics) {
+        this.statistics = statistics;
+    }
+}

--- a/src/main/java/com/freenow/apis/phrase/api/tag/dto/TagWithStatsStatisticsDTO.java
+++ b/src/main/java/com/freenow/apis/phrase/api/tag/dto/TagWithStatsStatisticsDTO.java
@@ -1,0 +1,26 @@
+package com.freenow.apis.phrase.api.tag.dto;
+
+public class TagWithStatsStatisticsDTO {
+
+    private LocalePreviewDTO locale;
+
+    public TagWithStatsStatisticsDTO() {
+    }
+
+    public TagWithStatsStatisticsDTO(final LocalePreviewDTO locale) {
+        this.locale = locale;
+    }
+
+    public LocalePreviewDTO getLocale() {
+        return locale;
+    }
+
+    public void setLocale(final LocalePreviewDTO locale) {
+        this.locale = locale;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("TagWithStatsStatisticsDTO{locale='%s'}", locale);
+    }
+}

--- a/src/main/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTask.java
+++ b/src/main/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTask.java
@@ -62,44 +62,6 @@ public class PhraseAppSyncTask implements Runnable
         LOG.debug("Initialized PhraseAppSyncTask with following projectIds: " + projectIdString + " and branches: " + branchesString);
     }
 
-    /*
-      authToken -
-      projectId -
-      scheme - http or https
-      host - host of api
-    */
-    public PhraseAppSyncTask(final String authToken, final String projectId, final String scheme, final String host)
-    {
-        this(authToken, projectId, null, singletonList(DEFAULT_BRANCH), scheme, host);
-    }
-
-
-    /**
-     * Constructs a new PhraseAppSyncTask which downloads translation from a project tag.
-     * @param authToken Phrase auth token (optional)
-     * @param projectId ID of the project in Phrase
-     * @param tags List of comma separated tag names of the project in Phrase
-     * @param scheme URL scheme of the Phrase API, e.g. {@code https}
-     * @param host Host of the Phrase API, e.g. {@code api.phraseapp.com}
-     */
-    public PhraseAppSyncTask(final String authToken, final String projectId, final String tags, final String scheme, final String host)
-    {
-        this(authToken, projectId, tags, singletonList(DEFAULT_BRANCH), scheme, host);
-    }
-
-    public PhraseAppSyncTask(final String authToken, final String projectId, final String tags, final List<String> branches, final String scheme, final String host)
-    {
-        projectIds = Collections.singletonList(projectId);
-        this.tags = tags;
-        this.branches = branches;
-        localeAPI = new PhraseLocaleAPI(authToken, scheme, host);
-        localeDownloadAPI = new PhraseLocaleDownloadAPI(authToken, scheme, host);
-        projectIdString = Joiner.on(",").join(projectIds);
-        branchesString = Joiner.on(",").join(branches);
-        fileService = new FileService();
-        LOG.debug("Initialized PhraseAppSyncTask with following projectIds: " + projectIdString + " and branches: " + branchesString);
-    }
-
     public PhraseAppSyncTask(final String authToken, final String projectId, PhraseLocaleAPI localeApi, PhraseLocaleDownloadAPI localeDownloadAPI, FileService fileService)
     {
         this(authToken, projectId, singletonList(DEFAULT_BRANCH), localeApi, localeDownloadAPI, fileService);
@@ -121,31 +83,37 @@ public class PhraseAppSyncTask implements Runnable
         LOG.debug("Initialized PhraseAppSyncTask with following projectIds: " + projectIdString + " and branches: " + branchesString);
     }
 
+
     /**
      * Constructs a new PhraseAppSyncTask by parsing a base URL of the Phrase API and setting Auth Token, Project and
      * Branches.
      *
      * @param authToken Phrase auth token
      * @param projectId ID of the project in Phrase
-     * @param branches List of branches in Phrase to query
-     * @param baseURL Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
+     * @param tags      List of comma separated tag names of the project in Phrase
+     * @param branches  List of branches in Phrase to query
+     * @param baseURL   Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
      */
-    public PhraseAppSyncTask(final String authToken, final String projectId, final List<String> branches, final String baseURL)
+    public PhraseAppSyncTask(final String authToken, final String projectId, final String tags, final List<String> branches, final String baseURL)
     {
         URI uri;
-        try {
+        try
+        {
             uri = new URI(baseURL);
-        } catch (NullPointerException | URISyntaxException e) {
+        }
+        catch (NullPointerException | URISyntaxException e)
+        {
             throw new PhraseAppSyncTaskException("Parsing base URL failed", e);
         }
 
-        if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https")) {
-            throw new PhraseAppSyncTaskException("Expect scheme in base URL to be 'http' or 'https', was '"+ uri.getScheme() +"'");
+        if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https"))
+        {
+            throw new PhraseAppSyncTaskException("Expect scheme in base URL to be 'http' or 'https', was '" + uri.getScheme() + "'");
         }
 
         String host = baseURL.replace(uri.getScheme() + "://", "");
         projectIds = Collections.singletonList(projectId);
-        this.tags = null;
+        this.tags = tags;
         this.branches = branches;
         localeAPI = new PhraseLocaleAPI(authToken, uri.getScheme(), host);
         localeDownloadAPI = new PhraseLocaleDownloadAPI(authToken, uri.getScheme(), host);
@@ -155,19 +123,49 @@ public class PhraseAppSyncTask implements Runnable
         LOG.debug("Initialized PhraseAppSyncTask with following projectIds: " + projectIdString + " and branches: " + branchesString);
     }
 
+
+    /**
+     * Constructs a new PhraseAppSyncTask by parsing a base URL of the Phrase API and setting Auth Token, Project and
+     * Branches.
+     *
+     * @param authToken Phrase auth token
+     * @param projectId ID of the project in Phrase
+     * @param branches  List of branches in Phrase to query
+     * @param baseURL   Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
+     */
+    public PhraseAppSyncTask(final String authToken, final String projectId, final List<String> branches, final String baseURL)
+    {
+        this(authToken, projectId, null, branches, baseURL);
+    }
+
+
     /**
      * Constructs a new PhraseAppSyncTask by parsing a base URL of the Phrase API and setting Auth Token and Project.
      * Uses the default branch in Phrase.
      *
      * @param authToken Phrase auth token
      * @param projectId ID of the project in Phrase
-     * @param baseURL Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
+     * @param baseURL   Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
      */
     public PhraseAppSyncTask(final String authToken, final String projectId, final String baseURL)
     {
-        this(authToken, projectId, singletonList(DEFAULT_BRANCH), baseURL);
+        this(authToken, projectId, null, singletonList(DEFAULT_BRANCH), baseURL);
     }
 
+
+    /**
+     * Constructs a new PhraseAppSyncTask by parsing a base URL of the Phrase API and setting Auth Token and Project.
+     * Uses the default branch in Phrase.
+     *
+     * @param authToken Phrase auth token
+     * @param tags      List of comma separated tag names of the project in Phrase
+     * @param projectId ID of the project in Phrase
+     * @param baseURL   Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
+     */
+    public PhraseAppSyncTask(final String authToken, final String projectId, final String tags, final String baseURL)
+    {
+        this(authToken, projectId, tags, singletonList(DEFAULT_BRANCH), baseURL);
+    }
 
     List<PhraseProject> getPhraseProjects()
     {

--- a/src/test/java/com/freenow/apis/phrase/api/localedownload/PhraseLocaleDownloadAPITest.java
+++ b/src/test/java/com/freenow/apis/phrase/api/localedownload/PhraseLocaleDownloadAPITest.java
@@ -4,7 +4,10 @@ import com.freenow.apis.phrase.api.format.Format;
 import com.freenow.apis.phrase.api.format.JavaPropertiesFormat;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.freenow.apis.phrase.config.TestConfig;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 import org.aeonbits.owner.ConfigFactory;
 import org.junit.Before;
 import org.junit.Rule;
@@ -112,9 +115,34 @@ public class PhraseLocaleDownloadAPITest
             .build();
 
         // WHEN
-        byte[] fileBytes = localeDownloadAPI.downloadLocale(projectId, branches.get(0), localeIdDe, format);
+        byte[] fileBytes = localeDownloadAPI.downloadLocale(projectId, branches.get(0), localeIdDe, format, null);
 
         // THEN
         assertNotNull(fileBytes);
+    }
+
+    @Test
+    public void testDownloadLocaleFilterByTags() throws IOException
+    {
+        // GIVEN
+        String authToken = cfg.authToken();
+        String projectId = cfg.projectId();
+        String scheme = cfg.scheme();
+        String host = cfg.host();
+        String tagName = cfg.tags();
+        String locale = cfg.localeIdDe();
+
+        PhraseLocaleDownloadAPI localeDownloadAPI = new PhraseLocaleDownloadAPI(authToken, scheme, host);
+
+        // WHEN
+        byte[] fileBytes = localeDownloadAPI.downloadLocale(
+            projectId,
+            locale,
+            tagName
+        );
+
+        // THEN
+        Properties properties = new Properties();
+        properties.load(new ByteArrayInputStream(fileBytes));
     }
 }

--- a/src/test/java/com/freenow/apis/phrase/api/localedownload/PhraseLocaleDownloadAPITestNew.java
+++ b/src/test/java/com/freenow/apis/phrase/api/localedownload/PhraseLocaleDownloadAPITestNew.java
@@ -4,7 +4,6 @@ import com.freenow.apis.phrase.api.format.Format;
 import com.freenow.apis.phrase.api.format.JavaPropertiesFormat;
 import com.freenow.apis.phrase.config.TestConfig;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-
 import java.util.List;
 import org.aeonbits.owner.ConfigFactory;
 import org.junit.Before;
@@ -71,7 +70,7 @@ public class PhraseLocaleDownloadAPITestNew
             .build();
 
         // WHEN
-        byte[] fileBytes = localeDownloadAPI.downloadLocale(projectId, branches.get(0), localeIdDe, format);
+        byte[] fileBytes = localeDownloadAPI.downloadLocale(projectId, branches.get(0), localeIdDe, format, null);
 
         // THEN
         assertNotNull(fileBytes);

--- a/src/test/java/com/freenow/apis/phrase/api/tag/PhraseTagAPITest.java
+++ b/src/test/java/com/freenow/apis/phrase/api/tag/PhraseTagAPITest.java
@@ -1,0 +1,47 @@
+package com.freenow.apis.phrase.api.tag;
+
+import com.freenow.apis.phrase.api.tag.dto.PhraseTagWithStatsDTO;
+import com.freenow.apis.phrase.config.TestConfig;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.aeonbits.owner.ConfigFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PhraseTagAPITest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(options().port(9999));
+
+    private TestConfig cfg;
+
+
+    @Before
+    public void beforeTest() {
+        cfg = ConfigFactory.create(TestConfig.class, System.getenv(), System.getProperties());
+    }
+
+    @Test
+    public void testGetSingleTag() {
+        // GIVEN
+        String authToken = cfg.authToken();
+        String projectId = cfg.projectId();
+        String scheme = cfg.scheme();
+        String host = cfg.host();
+        String tagName = cfg.tags();
+
+        PhraseTagAPI phraseTagAPI = new PhraseTagAPI(authToken, scheme, host);
+
+        // WHEN
+        PhraseTagWithStatsDTO phraseTagWithStatsDTO = phraseTagAPI.getSingleTag(projectId, tagName);
+
+        // THEN
+        assertNotNull(phraseTagWithStatsDTO);
+    }
+}

--- a/src/test/java/com/freenow/apis/phrase/config/TestConfig.java
+++ b/src/test/java/com/freenow/apis/phrase/config/TestConfig.java
@@ -25,4 +25,7 @@ public interface TestConfig extends Config
 
     @DefaultValue("http")
     String scheme();
+
+    @DefaultValue("tag-1234")
+    String tags();
 }

--- a/src/test/resources/__files/get-single-tag.json
+++ b/src/test/resources/__files/get-single-tag.json
@@ -1,0 +1,47 @@
+{
+  "name": "tag-1234",
+  "keys_count": 100,
+  "created_at": "2023-03-09T13:17:40Z",
+  "updated_at": "2023-03-09T13:17:40Z",
+  "statistics": [
+    {
+      "locale": {
+        "id": "locale-1234-en",
+        "name": "EN_Source",
+        "code": "en",
+        "statistics": {
+          "keys_total_count": 100,
+          "translations_completed_count": 100,
+          "translations_unverified_count": 0,
+          "keys_untranslated_count": 0
+        }
+      }
+    },
+    {
+      "locale": {
+        "id": "locale-1234-de",
+        "name": "de-DE",
+        "code": "de-DE",
+        "statistics": {
+          "keys_total_count": 100,
+          "translations_completed_count": 90,
+          "translations_unverified_count": 0,
+          "keys_untranslated_count": 10
+        }
+      }
+    },
+    {
+      "locale": {
+        "id": "locale-1234-es",
+        "name": "ES",
+        "code": "es",
+        "statistics": {
+          "keys_total_count": 100,
+          "translations_completed_count": 90,
+          "translations_unverified_count": 0,
+          "keys_untranslated_count": 10
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/mappings/mappings.json
+++ b/src/test/resources/mappings/mappings.json
@@ -21,6 +21,13 @@
         "queryParameters": {
           "file_format": {
             "equalTo": "properties"
+          },
+          "tags" : {
+            "or": [{
+              "equalTo" : "tag-1234"
+            }, {
+              "absent": true
+            }]
           }
         },
         "method": "GET"
@@ -67,6 +74,20 @@
       "response": {
         "status": 200,
         "bodyFileName": "get-translations-res.json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "name": "Get details and progress information on a single tag for a given project",
+      "request": {
+        "url": "/api/v2/projects/proj-1234/tags/tag-1234",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "get-single-tag.json",
         "headers": {
           "Content-Type": "application/json"
         }


### PR DESCRIPTION
**Summary:**
Download locales filtered by tags.

**Implementation details:**
- Bump version to 3.0.0
- A new constructor for `PhraseAppSyncTask` accepting a project tag.
- Removed constructors using `scheme` and `host` parameters.
- Updated client `PhraseLocaleAPI` supporting (as optional) a project tag.
- A new client `PhraseTagAPI` to fetch information related to a project tag.