### PR TITLE
Add constructor that accepts a base URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.free-now.apis</groupId>
     <artifactId>phrase-java-client</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>phrase-api</name>
     <description>This projects contains of services to handle the translations from [PhraseApp API
         v2](http://docs.phraseapp.com/api/v2/). It's supposed to expose Phrase translations as POJO or as File within the java world.</description>

--- a/src/main/java/com/freenow/apis/phrase/exception/PhraseAppSyncTaskException.java
+++ b/src/main/java/com/freenow/apis/phrase/exception/PhraseAppSyncTaskException.java
@@ -1,0 +1,14 @@
+package com.freenow.apis.phrase.exception;
+
+public class PhraseAppSyncTaskException extends RuntimeException
+{
+    public PhraseAppSyncTaskException(String message)
+    {
+        super(message);
+    }
+
+    public PhraseAppSyncTaskException(String message, Throwable throwable)
+    {
+        super(message, throwable);
+    }
+}

--- a/src/main/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTask.java
+++ b/src/main/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTask.java
@@ -117,7 +117,7 @@ public class PhraseAppSyncTask implements Runnable
         URI uri;
         try {
             uri = new URI(baseURL);
-        } catch (URISyntaxException e) {
+        } catch (NullPointerException | URISyntaxException e) {
             throw new PhraseAppSyncTaskException("Parsing base URL failed", e);
         }
 

--- a/src/main/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTask.java
+++ b/src/main/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTask.java
@@ -10,6 +10,8 @@ import com.freenow.apis.phrase.domainobject.locale.PhraseBranch;
 import com.freenow.apis.phrase.domainobject.locale.PhraseLocale;
 import com.freenow.apis.phrase.domainobject.locale.PhraseProject;
 import com.freenow.apis.phrase.exception.PhraseAppApiException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -98,6 +100,44 @@ public class PhraseAppSyncTask implements Runnable
         branchesString = Joiner.on(",").join(branches);
         this.fileService = fileService;
         LOG.debug("Initialized PhraseAppSyncTask with following projectIds: " + projectIdString + " and branches: " + branchesString);
+    }
+
+    /**
+     * Constructs a new PhraseAppSyncTask by parsing a base URL of the Phrase API and setting Auth Token, Project and
+     * Branches.
+     *
+     * @param authToken Phrase auth token
+     * @param projectId ID of the project in Phrase
+     * @param branches List of branches in Phrase to query
+     * @param baseURL Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
+     * @throws URISyntaxException If parsing of {@code baseURL} fails
+     */
+    public PhraseAppSyncTask(final String authToken, final String projectId, final List<String> branches, final String baseURL) throws URISyntaxException
+    {
+        URI uri = new URI(baseURL);
+        String host = baseURL.replace(uri.getScheme() + "://", "");
+        projectIds = Collections.singletonList(projectId);
+        this.branches = branches;
+        localeAPI = new PhraseLocaleAPI(authToken, uri.getScheme(), host);
+        localeDownloadAPI = new PhraseLocaleDownloadAPI(authToken, uri.getScheme(), host);
+        projectIdString = Joiner.on(",").join(projectIds);
+        branchesString = Joiner.on(",").join(branches);
+        fileService = new FileService();
+        LOG.debug("Initialized PhraseAppSyncTask with following projectIds: " + projectIdString + " and branches: " + branchesString);
+    }
+
+    /**
+     * Constructs a new PhraseAppSyncTask by parsing a base URL of the Phrase API and setting Auth Token and Project.
+     * Uses the default branch in Phrase.
+     *
+     * @param authToken Phrase auth token
+     * @param projectId ID of the project in Phrase
+     * @param baseURL Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
+     * @throws URISyntaxException If parsing of {@code baseURL} fails
+     */
+    public PhraseAppSyncTask(final String authToken, final String projectId, final String baseURL) throws URISyntaxException
+    {
+        this(authToken, projectId, Arrays.asList(DEFAULT_BRANCH), baseURL);
     }
 
 

--- a/src/main/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTask.java
+++ b/src/main/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTask.java
@@ -10,6 +10,7 @@ import com.freenow.apis.phrase.domainobject.locale.PhraseBranch;
 import com.freenow.apis.phrase.domainobject.locale.PhraseLocale;
 import com.freenow.apis.phrase.domainobject.locale.PhraseProject;
 import com.freenow.apis.phrase.exception.PhraseAppApiException;
+import com.freenow.apis.phrase.exception.PhraseAppSyncTaskException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -110,11 +111,20 @@ public class PhraseAppSyncTask implements Runnable
      * @param projectId ID of the project in Phrase
      * @param branches List of branches in Phrase to query
      * @param baseURL Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
-     * @throws URISyntaxException If parsing of {@code baseURL} fails
      */
-    public PhraseAppSyncTask(final String authToken, final String projectId, final List<String> branches, final String baseURL) throws URISyntaxException
+    public PhraseAppSyncTask(final String authToken, final String projectId, final List<String> branches, final String baseURL)
     {
-        URI uri = new URI(baseURL);
+        URI uri;
+        try {
+            uri = new URI(baseURL);
+        } catch (URISyntaxException e) {
+            throw new PhraseAppSyncTaskException("Parsing base URL failed", e);
+        }
+
+        if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https")) {
+            throw new PhraseAppSyncTaskException("Expect scheme in base URL to be 'http' or 'https', was '"+ uri.getScheme() +"'");
+        }
+
         String host = baseURL.replace(uri.getScheme() + "://", "");
         projectIds = Collections.singletonList(projectId);
         this.branches = branches;
@@ -133,9 +143,8 @@ public class PhraseAppSyncTask implements Runnable
      * @param authToken Phrase auth token
      * @param projectId ID of the project in Phrase
      * @param baseURL Base URL of the Phrase API, e.g. {@code https://api.phraseapp.com}
-     * @throws URISyntaxException If parsing of {@code baseURL} fails
      */
-    public PhraseAppSyncTask(final String authToken, final String projectId, final String baseURL) throws URISyntaxException
+    public PhraseAppSyncTask(final String authToken, final String projectId, final String baseURL)
     {
         this(authToken, projectId, Arrays.asList(DEFAULT_BRANCH), baseURL);
     }

--- a/src/test/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTaskTest.java
+++ b/src/test/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTaskTest.java
@@ -78,7 +78,7 @@ public class PhraseAppSyncTaskTest
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
-    public void testInvalidBaseURL()
+    public void testConstructor_invalidBaseURL()
     {
         exceptionRule.expect(PhraseAppSyncTaskException.class);
         exceptionRule.expectMessage("Parsing base URL failed");
@@ -86,11 +86,19 @@ public class PhraseAppSyncTaskTest
     }
 
     @Test
-    public void testInvalidBaseURLScheme()
+    public void testConstructor_invalidBaseURLScheme()
     {
         exceptionRule.expect(PhraseAppSyncTaskException.class);
         exceptionRule.expectMessage("Expect scheme in base URL to be 'http' or 'https', was 'htttps'");
         new PhraseAppSyncTask(cfg.authToken(), cfg.projectId(), "htttps://phrase.local/api");
+    }
+
+    @Test
+    public void testConstructor_baseURLNull()
+    {
+        exceptionRule.expect(PhraseAppSyncTaskException.class);
+        exceptionRule.expectMessage("Parsing base URL failed");
+        new PhraseAppSyncTask(cfg.authToken(), cfg.projectId(), null);
     }
 
 

--- a/src/test/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTaskTest.java
+++ b/src/test/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTaskTest.java
@@ -8,6 +8,7 @@ import com.freenow.apis.phrase.config.TestConfig;
 import com.freenow.apis.phrase.domainobject.locale.PhraseBranch;
 import com.freenow.apis.phrase.domainobject.locale.PhraseLocale;
 import com.freenow.apis.phrase.domainobject.locale.PhraseProject;
+import com.freenow.apis.phrase.exception.PhraseAppSyncTaskException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -24,6 +25,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import org.junit.rules.ExpectedException;
 
 public class PhraseAppSyncTaskTest
 {
@@ -70,6 +72,25 @@ public class PhraseAppSyncTaskTest
         );
 
         testRun(format, expectedEntries);
+    }
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void testInvalidBaseURL()
+    {
+        exceptionRule.expect(PhraseAppSyncTaskException.class);
+        exceptionRule.expectMessage("Parsing base URL failed");
+        new PhraseAppSyncTask(cfg.authToken(), cfg.projectId(), "https://phrase.local/api[]");
+    }
+
+    @Test
+    public void testInvalidBaseURLScheme()
+    {
+        exceptionRule.expect(PhraseAppSyncTaskException.class);
+        exceptionRule.expectMessage("Expect scheme in base URL to be 'http' or 'https', was 'htttps'");
+        new PhraseAppSyncTask(cfg.authToken(), cfg.projectId(), "htttps://phrase.local/api");
     }
 
 

--- a/src/test/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTaskTest.java
+++ b/src/test/java/com/freenow/apis/phrase/tasks/PhraseAppSyncTaskTest.java
@@ -20,12 +20,12 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import org.junit.rules.ExpectedException;
 
 public class PhraseAppSyncTaskTest
 {


### PR DESCRIPTION
Class `PhraseAppSyncTask` accepts scheme and host and constructs a URL for the API of Phrase.

This requirement leads to code that cannot deal with switching the scheme from HTTPS to HTTP.
Example code:

```kotlin
val phraseAppSyncTask = PhraseAppSyncTask(phraseAppAuthToken,
    phraseAppProjectId,
    "https",
    StringUtils.removeStart(phraseAppUrl, "https://")
)
```

If `phraseAppUrl` changes the scheme to `http` instead of `https`, calls made by `PhraseAppSyncTask` fail because it adds `https://` to all outgoing HTTP requests.

This change adds two new methods to the constructor of `PhraseAppSyncTask`. Each method accepts a parameter called `baseURL`. The code then handles the parsing of the URL. This way the scheme can be changed without changes to the application.